### PR TITLE
Factor providers into the X25519::Provider namespace

### DIFF
--- a/ext/x25519_precomputed/x25519_precomputed.c
+++ b/ext/x25519_precomputed/x25519_precomputed.c
@@ -7,25 +7,27 @@ the X25519 Diffie-Hellman algorithm
 #include "x25519_precomputed.h"
 
 static VALUE mX25519 = Qnil;
-static VALUE mX25519_Precomputed = Qnil;
+static VALUE mX25519_Provider = Qnil;
+static VALUE mX25519_Provider_Precomputed = Qnil;
 
-static VALUE mX25519_Scalar_multiply(VALUE self, VALUE scalar, VALUE montgomery_u);
-static VALUE mX25519_Scalar_multiply_base(VALUE self, VALUE scalar);
+static VALUE mX25519_Provider_Precomputed_scalarmult(VALUE self, VALUE scalar, VALUE montgomery_u);
+static VALUE mX25519_Provider_Precomputed_scalarmult_base(VALUE self, VALUE scalar);
 static VALUE mX25519_is_available(VALUE self);
 
 /* Initialize the x25519_precomputed C extension */
 void Init_x25519_precomputed()
 {
     mX25519 = rb_define_module("X25519");
-    mX25519_Precomputed = rb_define_module_under(mX25519, "Precomputed");
+    mX25519_Provider = rb_define_module_under(mX25519, "Provider");
+    mX25519_Provider_Precomputed = rb_define_module_under(mX25519_Provider, "Precomputed");
 
-    rb_define_singleton_method(mX25519_Precomputed, "multiply", mX25519_Scalar_multiply, 2);
-    rb_define_singleton_method(mX25519_Precomputed, "multiply_base", mX25519_Scalar_multiply_base, 1);
-    rb_define_singleton_method(mX25519_Precomputed, "available?", mX25519_is_available, 0);
+    rb_define_singleton_method(mX25519_Provider_Precomputed, "scalarmult", mX25519_Provider_Precomputed_scalarmult, 2);
+    rb_define_singleton_method(mX25519_Provider_Precomputed, "scalarmult_base", mX25519_Provider_Precomputed_scalarmult_base, 1);
+    rb_define_singleton_method(mX25519_Provider_Precomputed, "available?", mX25519_is_available, 0);
 }
 
 /* Variable-base scalar multiplication */
-static VALUE mX25519_Scalar_multiply(VALUE self, VALUE scalar, VALUE montgomery_u)
+static VALUE mX25519_Provider_Precomputed_scalarmult(VALUE self, VALUE scalar, VALUE montgomery_u)
 {
     /* X25519_KEY ensures inputs are aligned at 32-bytes */
     X25519_KEY raw_scalar, raw_montgomery_u, product;
@@ -58,7 +60,7 @@ static VALUE mX25519_Scalar_multiply(VALUE self, VALUE scalar, VALUE montgomery_
 }
 
 /* Fixed-base scalar multiplication */
-static VALUE mX25519_Scalar_multiply_base(VALUE self, VALUE scalar)
+static VALUE mX25519_Provider_Precomputed_scalarmult_base(VALUE self, VALUE scalar)
 {
     /* X25519_KEY ensures inputs are aligned at 32-bytes */
     X25519_KEY raw_scalar, product;

--- a/ext/x25519_ref10/x25519_ref10.c
+++ b/ext/x25519_ref10/x25519_ref10.c
@@ -7,23 +7,25 @@ X25519 Diffie-Hellman algorithm
 #include "x25519_ref10.h"
 
 static VALUE mX25519 = Qnil;
-static VALUE mX25519_Ref10 = Qnil;
+static VALUE mX25519_Provider = Qnil;
+static VALUE mX25519_Provider_Ref10 = Qnil;
 
-static VALUE mX25519_Scalar_multiply(VALUE self, VALUE scalar, VALUE montgomery_u);
-static VALUE mX25519_Scalar_multiply_base(VALUE self, VALUE scalar);
+static VALUE mX25519_Provider_Ref10_scalarmult(VALUE self, VALUE scalar, VALUE montgomery_u);
+static VALUE mX25519_Provider_Ref10_scalarmult_base(VALUE self, VALUE scalar);
 
 /* Initialize the x25519_ref10 C extension */
 void Init_x25519_ref10()
 {
     mX25519 = rb_define_module("X25519");
-    mX25519_Ref10 = rb_define_module_under(mX25519, "Ref10");
+    mX25519_Provider = rb_define_module_under(mX25519, "Provider");
+    mX25519_Provider_Ref10 = rb_define_module_under(mX25519_Provider, "Ref10");
 
-    rb_define_singleton_method(mX25519_Ref10, "multiply", mX25519_Scalar_multiply, 2);
-    rb_define_singleton_method(mX25519_Ref10, "multiply_base", mX25519_Scalar_multiply_base, 1);
+    rb_define_singleton_method(mX25519_Provider_Ref10, "scalarmult", mX25519_Provider_Ref10_scalarmult, 2);
+    rb_define_singleton_method(mX25519_Provider_Ref10, "scalarmult_base", mX25519_Provider_Ref10_scalarmult_base, 1);
 }
 
 /* Variable-base scalar multiplication */
-static VALUE mX25519_Scalar_multiply(VALUE self, VALUE scalar, VALUE montgomery_u)
+static VALUE mX25519_Provider_Ref10_scalarmult(VALUE self, VALUE scalar, VALUE montgomery_u)
 {
     X25519_KEY product;
 
@@ -57,7 +59,7 @@ static VALUE mX25519_Scalar_multiply(VALUE self, VALUE scalar, VALUE montgomery_
 }
 
 /* Fixed-base scalar multiplication */
-static VALUE mX25519_Scalar_multiply_base(VALUE self, VALUE scalar)
+static VALUE mX25519_Provider_Ref10_scalarmult_base(VALUE self, VALUE scalar)
 {
     X25519_KEY product;
 

--- a/lib/x25519.rb
+++ b/lib/x25519.rb
@@ -18,14 +18,13 @@ module X25519
   # Size of an X25519 key (public or private) in bytes
   KEY_SIZE = 32
 
+  # ref10 is the default provider
+  @provider = X25519::Provider::Ref10
+
   # X25519::Precomputed requires a 4th generation Intel Core CPU or newer,
   # so only enable it if we detect we're on a supported platform. Otherwise,
   # fall back to the ref10 portable C implementation.
-  @provider = if X25519::Precomputed.available?
-                X25519::Precomputed
-              else
-                X25519::Ref10
-              end
+  @provider = X25519::Provider::Precomputed if X25519::Provider::Precomputed.available?
 
   # Selected provider based on the logic above
   def provider
@@ -42,7 +41,7 @@ module X25519
   def diffie_hellman(scalar_bytes, montgomery_u_bytes)
     validate_key_bytes(scalar_bytes)
     validate_key_bytes(montgomery_u_bytes)
-    X25519.provider.multiply(scalar_bytes, montgomery_u_bytes)
+    X25519.provider.scalarmult(scalar_bytes, montgomery_u_bytes)
   end
 
   # Ensure a serialized key meets the requirements

--- a/lib/x25519/scalar.rb
+++ b/lib/x25519/scalar.rb
@@ -16,7 +16,7 @@ module X25519
     # @param bytes [String] 32-byte random secret scalar
     def initialize(bytes)
       X25519.validate_key_bytes(bytes)
-      @bytes = bytes
+      @scalar_bytes = bytes
     end
 
     # Variable-base scalar multiplication a.k.a. Diffie-Hellman
@@ -28,7 +28,7 @@ module X25519
     # @return [X25519::MontgomeryU] resulting point (i.e. D-H shared secret)
     def multiply(montgomery_u)
       raise TypeError, "expected X25519::MontgomeryU, got #{montgomery_u}" unless montgomery_u.is_a?(MontgomeryU)
-      MontgomeryU.new(X25519.provider.multiply(@bytes, montgomery_u.to_bytes))
+      MontgomeryU.new(X25519.provider.scalarmult(@scalar_bytes, montgomery_u.to_bytes))
     end
     alias diffie_hellman multiply
 
@@ -37,7 +37,7 @@ module X25519
     #
     # @return [X25519::MontgomeryU] resulting point (i.e. public key)
     def multiply_base
-      MontgomeryU.new(X25519.provider.multiply_base(@bytes))
+      MontgomeryU.new(X25519.provider.scalarmult_base(@scalar_bytes))
     end
     alias public_key multiply_base
 
@@ -45,7 +45,7 @@ module X25519
     #
     # @return [String] scalar converted to a bytestring
     def to_bytes
-      @bytes
+      @scalar_bytes
     end
 
     # String inspection that does not leak the private scalar

--- a/spec/support/provider_examples.rb
+++ b/spec/support/provider_examples.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-# Shared examples for all X25519 providers (e.g. X25519::Precomputed, X25519::Ref10)
-RSpec.shared_examples "X25519 provider" do
-  describe "#multiply" do
+# Shared examples for all X25519::Provider backends
+RSpec.shared_examples "X25519::Provider" do
+  describe "#scalarmult" do
     it "passes the RFC 7748 test vectors" do
       X25519_VARIABLE_BASE_TEST_VECTORS.each do |v|
-        shared_secret = described_class.multiply(unhex(v.scalar), unhex(v.input_coord))
+        shared_secret = described_class.scalarmult(unhex(v.scalar), unhex(v.input_coord))
         expect(hex(shared_secret)).to eq v.output_coord
       end
     end
   end
 
-  describe "#multiply_base" do
+  describe "#scalarmult_base" do
     it "passes the test vectors" do
       X25519_FIXED_BASE_TEST_VECTORS.each do |v|
-        shared_secret = described_class.multiply_base(unhex(v.scalar))
+        shared_secret = described_class.scalarmult_base(unhex(v.scalar))
         expect(hex(shared_secret)).to eq v.output_coord
       end
     end

--- a/spec/x25519/provider/precomputed_spec.rb
+++ b/spec/x25519/provider/precomputed_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe X25519::Precomputed do
+RSpec.describe X25519::Provider::Precomputed do
   if described_class.available?
-    include_examples "X25519 provider"
+    include_examples "X25519::Provider"
   else
     pending "#{described_class} provider not available on this CPU"
   end

--- a/spec/x25519/provider/ref10_spec.rb
+++ b/spec/x25519/provider/ref10_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe X25519::Provider::Ref10 do
+  include_examples "X25519::Provider"
+end

--- a/spec/x25519/ref10_spec.rb
+++ b/spec/x25519/ref10_spec.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe X25519::Ref10 do
-  include_examples "X25519 provider"
-end


### PR DESCRIPTION
This makes it clearer that these modules are providers and not something an end user needs to be familiar with.