### PR TITLE
Detect degenerate (i.e. all-zero) public keys (fixes #6)

### DIFF
--- a/lib/x25519/montgomery_u.rb
+++ b/lib/x25519/montgomery_u.rb
@@ -11,6 +11,11 @@ module X25519
     # @param bytes [String] 32-byte compressed Montgomery-u coordinate
     def initialize(bytes)
       X25519.validate_key_bytes(bytes)
+
+      # The point located at a Montgomery-u coordinate of zero always returns
+      # the point at zero regardless of which scalar it's multiplied with
+      raise InvalidKeyError, "degenerate public key" if bytes == ("\0" * KEY_SIZE)
+
       @bytes = bytes
     end
 

--- a/lib/x25519/scalar.rb
+++ b/lib/x25519/scalar.rb
@@ -26,20 +26,20 @@ module X25519
     # @param montgomery_u [X25519::MontgomeryU] coordinate of the public key/point to perform D-H with
     #
     # @return [X25519::MontgomeryU] resulting point (i.e. D-H shared secret)
-    def multiply(montgomery_u)
+    def diffie_hellman(montgomery_u)
       raise TypeError, "expected X25519::MontgomeryU, got #{montgomery_u}" unless montgomery_u.is_a?(MontgomeryU)
-      MontgomeryU.new(X25519.provider.scalarmult(@scalar_bytes, montgomery_u.to_bytes))
+      MontgomeryU.new(X25519.diffie_hellman(@scalar_bytes, montgomery_u.to_bytes))
     end
-    alias diffie_hellman multiply
+    alias multiply diffie_hellman
 
     # Fixed-base scalar multiplication. Calculates a public key from a
     # private scalar
     #
     # @return [X25519::MontgomeryU] resulting point (i.e. public key)
-    def multiply_base
-      MontgomeryU.new(X25519.provider.scalarmult_base(@scalar_bytes))
+    def public_key
+      MontgomeryU.new(X25519.calculate_public_key(@scalar_bytes))
     end
-    alias public_key multiply_base
+    alias multiply_base public_key
 
     # Return a bytestring representation of this scalar
     #

--- a/spec/x25519_spec.rb
+++ b/spec/x25519_spec.rb
@@ -6,12 +6,22 @@ RSpec.describe X25519 do
   end
 
   describe ".diffie_hellman" do
+    let(:example_scalar) { unhex(X25519::TestVectors::VARIABLE_BASE.first.scalar) }
+
     it "raises ArgumentError if one of the inputs is the wrong length" do
       expect { described_class.diffie_hellman("foo", "bar") }.to raise_error(ArgumentError)
     end
 
     it "raises TypeError if one of the inputs is nil" do
       expect { described_class.diffie_hellman(nil, "foobar") }.to raise_error(TypeError)
+    end
+
+    it "raises InvalidKeyError if the point is degenerate" do
+      degenerate_key = "\0" * X25519::KEY_SIZE
+
+      expect do
+        described_class.diffie_hellman(example_scalar, degenerate_key)
+      end.to raise_error(X25519::InvalidKeyError)
     end
 
     context "RFC 7748 test vectors" do


### PR DESCRIPTION
All-zero public keys (i.e. Montgomery-u coordinates) have a scalar multiplication of all-zero (i.e. themselves) regardless of the input scalar.

It's somewhat debatable as to whether an explicit check should be added for this case (the Curve25519 web site, for example, suggests avoiding it), but I'm going to side with caution here and go ahead and add the check.

This implementation performs the check in the high-level Ruby API, ensuring that we don't have to depend on every last provider to implement it.